### PR TITLE
Fix device path and replace keyserver

### DIFF
--- a/cloudformation/jenkins.json
+++ b/cloudformation/jenkins.json
@@ -597,7 +597,7 @@
           },
           {
             "Name": "Filesystem",
-            "Value": "/dev/disk/by-uuid/8ea401db-b84b-4cd6-a628-d72f30bbf1e5"
+            "Value": "/dev/xvda1"
           },
           {
             "Name": "MountPath",

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -39,7 +39,7 @@
         "sudo apt-get install unzip -y",
         "sudo apt-get install libwww-perl libdatetime-perl -y",
         "sudo apt-get install apt-transport-https ca-certificates -y",
-        "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
+        "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
         "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main | sudo tee --append /etc/apt/sources.list.d/docker.list",
         "sudo apt-get update  -y ",
         "sudo apt-cache policy docker-engine",


### PR DESCRIPTION
First, thank you for this repo, it was exactly what I needed. I was able to get the entire stack up and running with only two minor tweaks that I though should be pushed up stream.

First, you have what appears to be a hardcoded device in the cloudwatch alarms. I replaced it with the generic device path `/dev/xvda1`. Note that because this is a cloud based ubuntu image, it automatically switches from `/dev/sda1` to `/dev/xvda1` to use the Xen storage devices.

Second, the keyserver you use to retrieve the docker GPG key appears to have problems serving keys (see [this issue for more info](https://github.com/docker/docker/issues/20022)). I replaced it with the Ubuntu keyserver that seems much more reliable.

I also upgraded my fork from 14.04 to 16.04 with zero complications, but wasn't sure if you wanted that pushed up stream as well.